### PR TITLE
Extend VQE to include orbital optimization

### DIFF
--- a/qc2/algorithms/__init__.py
+++ b/qc2/algorithms/__init__.py
@@ -1,0 +1,10 @@
+"""qc2 VQE package."""
+from .orbital_optimization import OrbitalOptimization
+from .vqe import VQE
+from .oo_vqe import oo_VQE
+
+__all__ = [
+    'OrbitalOptimization',
+    'VQE',
+    'oo_VQE'
+]

--- a/qc2/algorithms/oo_vqe.py
+++ b/qc2/algorithms/oo_vqe.py
@@ -1,0 +1,10 @@
+""""Module docstring."""
+from qc2.algorithms.vqe import VQE
+
+
+class oo_VQE(VQE):
+    """Docstring."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Module Docstrings."""
+        VQE.__init__(self, *args, **kwargs)

--- a/qc2/algorithms/orbital_optimization.py
+++ b/qc2/algorithms/orbital_optimization.py
@@ -1,0 +1,10 @@
+""""Module docstring."""
+
+
+class OrbitalOptimization:
+    """Docstring."""
+    def __init__(
+                self,
+                qc2data
+    ) -> None:
+        """Module Docstrings."""

--- a/qc2/algorithms/vqe.py
+++ b/qc2/algorithms/vqe.py
@@ -1,0 +1,102 @@
+""""Module docstring."""
+from typing import Tuple, List
+
+from qc2.data import qc2Data
+
+
+def _import_sdk(package):
+    """Import required modules specific to a chosen SDK."""
+    try:
+        if package == 'qiskit':
+            from qiskit_nature.second_q.circuit.library import HartreeFock as hf
+            from qiskit_nature.second_q.circuit.library import UCCSD as ucc
+            from qiskit_nature.second_q.mappers import JordanWignerMapper as mapper
+            from qiskit.primitives import Estimator as estimator
+            # import also later the backend
+            return mapper, hf, ucc, estimator
+    except ImportError as error:
+        raise ImportError(
+            "Unable to import the requested package. "
+        ) from error
+
+
+class VQE:
+    """Docstring."""
+
+    def __init__(
+            self,
+            qc2data: qc2Data,
+            n_active_electrons: Tuple[int, int],
+            n_active_orbitals: int,
+            quantum_computing_sdk: str = 'qiskit'
+    ) -> None:
+        """Module Docstrings."""
+        self.qc2data = qc2data
+
+        # active space parameters
+        self.n_active_orbitals = n_active_orbitals
+        self.n_active_electrons = n_active_electrons
+
+        # get electronic structure data
+        self._get_qchem_data()
+
+        # circuit data
+        self.sdk = quantum_computing_sdk
+        self.mapper = None
+        self.reference_state = None
+        self.ansatz = None
+        self.estimator = None
+
+    def _get_qchem_data(self) -> None:
+        """Run ASE calculator"""
+        self.qc2data.run()
+
+    def _build_ansatz(self) -> None:
+        """Set up VQE circuit."""
+        # set up reference quantum circuit
+        mapper, hf, ucc, estimator = _import_sdk(self.sdk)  # => provisory solution
+        self.estimator = estimator()
+        self.mapper = mapper()
+        self.reference_state = hf(
+            self.n_active_orbitals,
+            self.n_active_electrons,
+            self.mapper,
+        )
+        # set up the ansatz using unitary CC as variational form
+        self.ansatz = ucc(
+            self.n_active_orbitals,
+            self.n_active_electrons,
+            self.mapper,
+            initial_state=self.reference_state
+        )
+
+    def get_rdms(self, var_params: List):
+        """Get 1- and 2-RDMs."""
+        # set up VQE a ansatz
+        self._build_ansatz()
+        if len(var_params) != self.ansatz.num_parameters:
+            raise ValueError("Incorrect dimension for amplitude list.")
+
+        # get the fermionic hamiltonian
+        _, core_energy, fermionic_op = self.qc2data.get_fermionic_hamiltonian(
+            self.n_active_electrons, self.n_active_orbitals
+        )
+
+        # run over the terms of the hamiltonian
+        for key, coeff in fermionic_op.terms():
+            # assign indices depending on one- or two-body term
+            length = len(key)
+            if length == 2:
+                print(key, len(key))
+            elif length == 4:
+                print(key, len(key))
+            # then calculate expectation values for each of those terms
+            # and save into matrices...these are the RDMs!
+
+    def energy_from_rdms(self):
+        """Calculate energy based on 1- and 2-RDMs."""
+        raise NotImplementedError
+
+    def run(self) -> None:
+        """Run VQE."""
+        raise NotImplementedError


### PR DESCRIPTION
# Aim

Adding orbital parametrization into variational forms as per issue #24.

# Idea
The idea is illustrated in following pseudo-code:

<img width="436" alt="oo_vqe" src="https://github.com/qc2nl/qc2/assets/114645116/c7f354a2-50bc-4016-a32a-ad43707165cc">

A summary of the steps we should follow to implement it is given below:

1. **Perform a standard VQE with the initial (reference) MOs and hamiltonian.** This will allow us to obtain the best circuit parameters $`\boldsymbol{\theta}^{*}`$.

2. **Use $`\boldsymbol{\theta}^{*}`$ and calculate 1- and 2-RDMs (Reduced Density Matrices).** These are terms of the type $`\gamma_{pq}(\boldsymbol{\theta}) = \langle\psi(\boldsymbol{\theta})| a_{p\sigma}^\dagger a_{q\sigma} |\psi(\boldsymbol{\theta})\rangle`$ and $`\Gamma_{pqrs}(\boldsymbol{\theta}) = \langle\psi(\boldsymbol{\theta})| a_{p\sigma}^\dagger a_{r\tau}^\dagger a_{s\tau} a_{q\sigma} |\psi(\boldsymbol{\theta})\rangle`$. To implement them, we need to decompose/group the original fermionic hamiltonian, convert these terms into qubit representation and measure their expectation values.

4. **Calculate the electronic structure energy using the measured RMDs**.
This is done using the RDM matrix elements, electronic integrals in AO basis and the MO coefficients into the expression:
$`E(C, \gamma(\boldsymbol{\theta^{*}}), \Gamma(\boldsymbol{\theta^{*}})) = E_{\rm nuc} + E_{\rm core}(C) + \sum_{tu} h_{tu}(C) \gamma_{tu}(\boldsymbol{\theta^{*}}) + \sum_{tuvw} g_{tuvw}(C) \Gamma_{tuvw}(\boldsymbol{\theta^{*}})`$,
where $`h_{tu}(C)`$ and $`g_{tuvw}(C)`$ contains the active one- and two-body terms (in MO basis).

5. **Optimize the orbital parameters $`\kappa`$ and the corresponding skew symmetric matrix $`\boldsymbol{K}`$**. This is done via classical Newton-Raphson steps up to convergence, with the analytic derivatives being defined on the basis of the calculated RDMs.

6. **Rotate the original orbitals** by multiplying old MO coeffs by $`\exp(-\boldsymbol{K})`$. This would correspond to the mapping $`\boldsymbol{C'} \rightarrow \boldsymbol{C} e^{-\boldsymbol{K}}`$. With the new rotated MO coeffs ($`\boldsymbol{C'}`$), we calculate new one- and two-body terms and reconstruct the hamiltonian. The final energy is then given by the functional $`E(C', \gamma(\boldsymbol{\theta^{*}}), \Gamma(\boldsymbol{\theta^{*}}))`$.

8. **Iterate over the above steps** until energy convergence, with the previously calculated $`C'`$, and $`\theta^{*}`$s serving as initial parameters for the next run.

# Key concepts

- **Calculation of RDMs:**
  - [Hartree-Fock on a superconducting qubit quantum computer (Appendix A)](https://www.science.org/doi/10.1126/science.abb9811)
  - [Quantum Chemistry without Wave Functions: Two-Electron Reduced Density Matrices](https://pubs.acs.org/doi/10.1021/ar050029d)

- **Classical optimization of orbital coeffs via NR:**
  - [A state-averaged orbital-optimized hybrid quantum-classical algorithm for ground and excited states (Appendix C and D)](https://iopscience.iop.org/article/10.1088/2058-9565/abd334)
  - [Orbital-optimized pair-correlated electron simulations on trapped-ion quantum computers (Sup Info)](https://www.nature.com/articles/s41534-023-00730-8)
  - [Quantum orbital-optimized unitary coupled cluster methods](https://pubs.aip.org/aip/jcp/article-abstract/152/12/124107/953761/Quantum-orbital-optimized-unitary-coupled-cluster?redirectedFrom=fulltext)
  - [Orbital optimized unitary coupled cluster theory for quantum computers](https://journals.aps.org/prresearch/abstract/10.1103/PhysRevResearch.2.033421)
  - [The complete active space SCF (CASSCF) method in a Newton–Raphson formulation](https://pubs.aip.org/aip/jcp/article-abstract/74/4/2384/988865/The-complete-active-space-SCF-CASSCF-method-in-a?redirectedFrom=fulltext)
 
# Tasks

- [ ] Implementation of `VQE` and `oo_VQE(VQE)` classes
  - [ ] Add method that sets up the reference circuit and variational UCC form: `oo_VQE._build_ansatz(self)`
  - [ ] Add method that runs VQE optimization: `oo_VQE.run(self)`
  - [ ] Add method to calculate RDMs for given circuit parameters: `oo_VQE.get_rdms(self, circuit_var_params: List):`
  - [ ] Add method to get electronic energy from RDMs: `oo_VQE.get_energy_from_rdms(self, circuit_var_params: List)`
  - [ ] Add method that iterates over all steps: `oo_VQE.iterate(self, circuit_var_params: List, orbital_params: List)`

- [ ] Implementation of `OrbitalOptimization` class
  - [ ] Add method that performs NR steps based on input RDMs and initial orbital params $`\boldsymbol{K}`$: `OrbitalOptimization.minimize(self, one_rdm: nd.array, two_rdm: nd.array, orbital_params: List)`
  - [ ] Add method to rotate MOs or even transform the Hamiltonian directly: `OrbitalOptimization.get_transformed_mo(self, mo_coeff, orbital_params: List):`
  - [ ] Add method that calculates electronic energy from input RDMs and MO coefficients: `OrbitalOptimization.energy_from_mo_coeff(self, mo_coeff, one_rdm, two_rdm):`